### PR TITLE
FISH-5911 Backport Apache Santuario Fix for CVE-2021-40690

### DIFF
--- a/src/main/java/org/apache/xml/security/keys/keyresolver/implementations/KeyInfoReferenceResolver.java
+++ b/src/main/java/org/apache/xml/security/keys/keyresolver/implementations/KeyInfoReferenceResolver.java
@@ -199,6 +199,7 @@ public class KeyInfoReferenceResolver extends KeyResolverSpi {
         validateReference(referentElement);
 
         KeyInfo referent = new KeyInfo(referentElement, baseURI);
+        referent.setSecureValidation(secureValidation);
         referent.addStorageResolver(storage);
         return referent;
     }
@@ -217,7 +218,7 @@ public class KeyInfoReferenceResolver extends KeyResolverSpi {
         }
 
         KeyInfo referent = new KeyInfo(referentElement, "");
-        if (referent.containsKeyInfoReference()) {
+        if (referent.containsKeyInfoReference() || referent.containsRetrievalMethod()) {
             if (secureValidation) {
                 throw new XMLSecurityException("KeyInfoReferenceResolver.InvalidReferentElement.ReferenceWithSecure");
             } else {

--- a/src/main/java/org/apache/xml/security/resource/xmlsecurity_en.properties
+++ b/src/main/java/org/apache/xml/security/resource/xmlsecurity_en.properties
@@ -120,6 +120,7 @@ signature.Transform.ForbiddenTransform = Transform {0} is forbidden when secure 
 signature.Transform.NotYetImplemented = Transform {0} not yet implemented
 signature.Transform.NullPointerTransform = Null pointer as URI. Programming bug?
 signature.Transform.UnknownTransform = Unknown transformation. No handler installed for URI {0}
+signature.Transform.XPathError = Error evaluating XPath expression
 signature.Transform.node = Current Node: {0}
 signature.Transform.nodeAndType = Current Node: {0}, type: {1} 
 signature.Util.BignumNonPositive = bigInteger.signum() must be positive

--- a/src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java
+++ b/src/main/java/org/apache/xml/security/signature/XMLSignatureInput.java
@@ -526,7 +526,7 @@ public class XMLSignatureInput {
                 convertToNodes();
             } catch (Exception e) {
                 throw new XMLSecurityRuntimeException(
-                    "signature.XMLSignatureInput.nodesetReference", e
+                    "signature.XMLSignatureInput.nodesetReference"
                 );
             }
         }

--- a/src/main/java/org/apache/xml/security/transforms/implementations/TransformXPath.java
+++ b/src/main/java/org/apache/xml/security/transforms/implementations/TransformXPath.java
@@ -51,7 +51,7 @@ public class TransformXPath extends TransformSpi {
 
     /** Field implementedTransformURI */
     public static final String implementedTransformURI = Transforms.TRANSFORM_XPATH;
-    
+
     /**
      * Method engineGetURI
      *
@@ -100,7 +100,7 @@ public class TransformXPath extends TransformSpi {
                     DOMException.HIERARCHY_REQUEST_ERR, "Text must be in ds:Xpath"
                 );
             }
-            
+
             XPathFactory xpathFactory = XPathFactory.newInstance();
             XPathAPI xpathAPIInstance = xpathFactory.newXPathAPI();
             input.addNodeFilter(new XPathNodeFilter(xpathElement, xpathnode, str, xpathAPIInstance));
@@ -120,12 +120,12 @@ public class TransformXPath extends TransformSpi {
     }
 
     static class XPathNodeFilter implements NodeFilter {
-        
+
         XPathAPI xPathAPI;
-        Node xpathnode; 
+        Node xpathnode;
         Element xpathElement;
         String str;
-        
+
         XPathNodeFilter(Element xpathElement, Node xpathnode, String str, XPathAPI xPathAPI) {
             this.xpathnode = xpathnode;
             this.str = str;
@@ -136,7 +136,7 @@ public class TransformXPath extends TransformSpi {
         /**
          * @see org.apache.xml.security.signature.NodeFilter#isNodeInclude(org.w3c.dom.Node)
          */
-        public int isNodeInclude(Node currentNode) {			
+        public int isNodeInclude(Node currentNode) {
             try {
                 boolean include = xPathAPI.evaluate(currentNode, xpathnode, str, xpathElement);
                 if (include) {
@@ -144,17 +144,13 @@ public class TransformXPath extends TransformSpi {
                 }
                 return 0;
             } catch (TransformerException e) {
-                Object[] eArgs = {currentNode};
-                throw new XMLSecurityRuntimeException("signature.Transform.node", eArgs, e);
-            } catch (Exception e) {
-                Object[] eArgs = {currentNode, Short.valueOf(currentNode.getNodeType())};
-                throw new XMLSecurityRuntimeException("signature.Transform.nodeAndType",eArgs, e);
+                throw new XMLSecurityRuntimeException("signature.Transform.XPathError");
             }
         }
-        
+
         public int isNodeIncludeDO(Node n, int level) {
             return isNodeInclude(n);
         }
-        
+
     }
 }

--- a/src/test/java/org/apache/xml/security/test/dom/keys/keyresolver/KeyInfoReferenceResolverTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/keys/keyresolver/KeyInfoReferenceResolverTest.java
@@ -128,11 +128,24 @@ public class KeyInfoReferenceResolverTest extends Assert {
         assertNull(keyInfo.getPublicKey());
     }
 
+    @org.junit.Test
+    public void testKeyInfoReferenceToRetrievalMethodNotAllowed() throws Exception {
+        Document doc = loadXML("KeyInfoReference-RSA-RetrievalMethod.xml");
+        markKeyInfoIdAttrs(doc);
+        markEncodedKeyValueIdAttrs(doc);
+
+        Element referenceElement = doc.getElementById("theReference");
+        assertNotNull(referenceElement);
+
+        KeyInfo keyInfo = new KeyInfo(referenceElement, "");
+        assertNull(keyInfo.getPublicKey());
+    }
+
     // Utility methods
 
     private String getControlFilePath(String fileName) {
-        return BASEDIR + SEP + "src" + SEP + "test" + SEP + "resources" + 
-            SEP + "org" + SEP + "apache" + SEP + "xml" + SEP + "security" + 
+        return BASEDIR + SEP + "src" + SEP + "test" + SEP + "resources" +
+            SEP + "org" + SEP + "apache" + SEP + "xml" + SEP + "security" +
             SEP + "keyresolver" +
             SEP + fileName;
     }
@@ -157,6 +170,14 @@ public class KeyInfoReferenceResolverTest extends Assert {
 
     private void markKeyInfoIdAttrs(Document doc) {
         NodeList nl = doc.getElementsByTagNameNS(Constants.SignatureSpecNS, Constants._TAG_KEYINFO);
+        for (int i = 0; i < nl.getLength(); i++) {
+            Element keyInfoElement = (Element) nl.item(i);
+            keyInfoElement.setIdAttributeNS(null, Constants._ATT_ID, true);
+        }
+    }
+
+    private void markEncodedKeyValueIdAttrs(Document doc) {
+        NodeList nl = doc.getElementsByTagNameNS(Constants.SignatureSpec11NS, Constants._TAG_DERENCODEDKEYVALUE);
         for (int i = 0; i < nl.getLength(); i++) {
             Element keyInfoElement = (Element) nl.item(i);
             keyInfoElement.setIdAttributeNS(null, Constants._ATT_ID, true);

--- a/src/test/resources/org/apache/xml/security/keyresolver/KeyInfoReference-RSA-RetrievalMethod.xml
+++ b/src/test/resources/org/apache/xml/security/keyresolver/KeyInfoReference-RSA-RetrievalMethod.xml
@@ -1,0 +1,22 @@
+<test:root xmlns:test="http://www.example.org/test">
+
+  <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="theRealKey">
+    <dsig11:DEREncodedKeyValue Id="theRealKey2" xmlns:dsig11="http://www.w3.org/2009/xmldsig11#">
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmDnHagSzfia3N7jOaMSp4VIZjK2lxZgN
+      X/2z98YLp1XE3cvpP+mOvX3gENWQuX3uoix+2qroZ0BFHzhzf4E7is5Q9+42ZFi5naFk3c/B0Q8A
+      jtHtWUEZ8VPPBZggz6uJ1ttJS7YDP6XVjaw6SN1bJSD4/lWNIVsh95kuhunbOef6x/kyIbBz9wF4
+      S0//G6zPD4GG7/jJ+sDXe+bAgPB1qwhLhrK3N1jGuDZkGGcY/c4b7aba0B0rognwKlygv16GoA/n
+      zWehxih7clhmMTzP2VWa3Q2GcN8ETe00dz68KtS7GF6W15qftjUvRXEKSoPz86ZsP30jIH1tvIrs
+      qSh/kwIDAQAB
+    </dsig11:DEREncodedKeyValue>
+  </ds:KeyInfo>
+
+  <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="retrievalMethod">
+    <ds:RetrievalMethod URI="#theRealKey2"/>
+  </ds:KeyInfo>
+  
+  <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="theReference">
+    <dsig11:KeyInfoReference xmlns:dsig11="http://www.w3.org/2009/xmldsig11#" URI="#retrievalMethod" />
+  </ds:KeyInfo>
+
+</test:root>


### PR DESCRIPTION
[CVE-2021-40690 ](https://nvd.nist.gov/vuln/detail/CVE-2021-40690#vulnCurrentDescriptionTitle) identified a security issue with Santuario versions prior to 2.2.3 and 2.1.7.

Neither of those two versions compile on JDK 7 so this backports the fix to Santuario 1.5.8 for Payara 4 compatibility.

Tested Metro-Wsit compiles on JDK 7 and Payara 4 starts on JDK 7 and JDK 8.